### PR TITLE
Refine identifying keyword kind (in prep for fix)

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -497,19 +497,24 @@ export class Transpiler {
     this.emit(translated);
   }
 
-  static DART_KEYWORDS =
-      ('abstract as assert async await break case catch class const continue ' +
-       'default deferred do dynamic else enum export extends external factory false final ' +
-       'finally for get if implements import in is library new null operator part rethrow return' +
-       ' set static super switch sync this throw true try typedef var void while with yield')
-          .split(/ /);
+  // For the Dart keyword list see
+  // https://www.dartlang.org/docs/dart-up-and-running/ch02.html#keywords
+  static DART_RESERVED_WORDS =
+      ('assert break case catch class const continue default do else enum extends false final ' +
+      'finally for if in is new null rethrow return super switch this throw true try var void ' +
+      'while with').split(/ /);
+
+  // These are the built-in and limited keywords.
+  static DART_OTHER_KEYWORDS =
+      ('abstract as async await deferred dynamic export external factory get implements import ' +
+      'library operator part set static sync typedef yield').split(/ /);
 
   getLibraryName(nameForTest: string = null) {
     var parts = (nameForTest || this.relativeFileName).split('/');
     return parts.filter((p) => p.length > 0)
         .map((p) => p.replace(/[^\w.]/g, '_'))
         .map((p) => p.replace(/\.[jt]s$/g, ''))
-        .map((p) => Transpiler.DART_KEYWORDS.indexOf(p) != -1 ? '_' + p : p)
+        .map((p) => Transpiler.DART_RESERVED_WORDS.indexOf(p) != -1 ? '_' + p : p)
         .join('.');
   }
 

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -572,8 +572,11 @@ describe('transpile to dart', () => {
       var res = transpiler.translateProgram(program, 'a/b/c.ts');
       chai.expect(res).to.equal(' library a.b.c ; var x ;');
     });
-    it('handles keywords', () => {
+    it('handles reserved words', () => {
       chai.expect(transpiler.getLibraryName('/a/for/in/do/x')).to.equal('a._for._in._do.x');
+    });
+    it('handles built-in and limited keywords', () => {
+      chai.expect(transpiler.getLibraryName('/as/if/sync/x')).to.equal('as._if.sync.x');
     });
     it('handles file extensions', () => {
       chai.expect(transpiler.getLibraryName('a/x.ts')).to.equal('a.x');


### PR DESCRIPTION
* This is preparatory work for #113.
* Note that there are **three kinds of keywords**: reserved, built-in, and
limited. Only reserved words must be avoided when porting from JS to
Dart (see [footnote 1 in Dart Up and Running Chap. 2](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#keywords)).
* `getLibraryName()` has been tweaked to only rename libraries having names that match a *reserved word*.
* Added test case for built-in and limited keywords.