### PR TITLE
fix(const): fix processing of CONST_EXPR

### DIFF
--- a/lib/call.ts
+++ b/lib/call.ts
@@ -41,18 +41,22 @@ class CallTranspiler extends base.TranspilerStep {
 
   private visitCall(c: ts.CallExpression) {
     var fnName = base.ident(c.expression);
-    if (fnName === 'CONST_EXPR') {
-      // The special function CONST_EXPR translates to Dart's const expressions.
+    var isConstExpr = fnName === 'CONST_EXPR';// The special function CONST_EXPR translates to Dart's const expressions.
+    if (isConstExpr) {
       this.emit('const');
       if (c.arguments.length !== 1) this.reportError(c, 'CONST_EXPR takes exactly one argument');
     } else {
       this.visit(c.expression);
     }
-    this.emit('(');
+    if (!isConstExpr) {
+      this.emit('(');
+    }
     if (!this.handleNamedParamsCall(c)) {
       this.visitList(c.arguments);
     }
-    this.emit(')');
+    if (!isConstExpr) {
+      this.emit(')');
+    }
   }
 
   private handleNamedParamsCall(c: ts.CallExpression): boolean {

--- a/test/call_test.ts
+++ b/test/call_test.ts
@@ -46,7 +46,7 @@ describe('calls', () => {
   it('translates CONST_EXPR(...) to const (...)', () => {
     expectTranslate('import {CONST_EXPR} from "angular2/facade/lang.ts";\n' +
                     'const x = CONST_EXPR([]);')
-        .to.equal(' const x = const ( [ ] ) ;');
+        .to.equal(' const x = const [ ] ;');
     expectErroneousCode('CONST_EXPR()').to.throw(/exactly one argument/);
     expectErroneousCode('CONST_EXPR(1, 2)').to.throw(/exactly one argument/);
   });


### PR DESCRIPTION
With the current implementation `const numbers = CONST_EXPR([1, 2, 3]);` would result in `const numbers = const([1, 2, 3]);` which doesn't seem to be valid Dart code as it results in:

> error: type name expected

I think we should be simply generating `const numbers = const [1, 2, 3];`