### PR TITLE
fix: properly handle regexp literals.

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -111,6 +111,15 @@ export class FacadeConverter extends base.TranspilerBase {
       this.visit(context);
       this.emit('is List');
     },
+    'RegExp.test': (c: ts.CallExpression, context: ts.Expression) => {
+      this.visit(context);
+      this.emitCall('hasMatch', c.arguments);
+    },
+    'RegExp.exec': (c: ts.CallExpression, context: ts.Expression) => {
+      this.visit(context);
+      this.emitCall('allMatches', c.arguments);
+      this.emitCall('toList');
+    },
   };
 
   private subs: ts.Map<ts.Map<FacadeHandler>> = {

--- a/lib/literal.ts
+++ b/lib/literal.ts
@@ -93,7 +93,14 @@ class LiteralTranspiler extends base.TranspilerBase {
         this.emit('null');
         break;
       case ts.SyntaxKind.RegularExpressionLiteral:
-        this.emit((<ts.LiteralExpression>node).text);
+        this.emit('new RegExp (');
+        this.emit('r\'');
+        var regExp = (<ts.LiteralExpression>node).text;
+        regExp = regExp.substring(1, regExp.length - 1);  // cut off /.../ chars.
+        regExp = regExp.replace('\'', '\' + "\'" + r\'');  // handle nested quotes by concatenation.
+        this.emitNoSpace(regExp);
+        this.emitNoSpace('\'');
+        this.emit(')');
         break;
       case ts.SyntaxKind.ThisKeyword:
         this.emit('this');

--- a/test/e2e/helloworld.ts
+++ b/test/e2e/helloworld.ts
@@ -21,5 +21,9 @@ function main(): void {
     var b = "world";
     t.expect(`${a} ${b}`, t.equals("hello world"));
   });
+  t.test("regexp", function() {
+    t.expect(/o\./.test("fo.o"), t.equals(true));
+    t.expect(/o/.exec("fo.o").length, t.equals(2));
+  });
   t.test("const expr", function() { t.expect(SomeArray[0], t.equals(1)); });
 }

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -62,6 +62,11 @@ describe('type based translation', () => {
     });
   });
 
+  describe('regexp', () => {
+    expectWithTypes('var x = /a/; x.test("a");')
+        .to.equal(' var x = new RegExp ( r\'a\' ) ; x . hasMatch ( "a" ) ;');
+  });
+
   describe('builtin functions', () => {
     it('translates CONST_EXPR(...) to const (...)', () => {
       expectWithTypes('import {CONST_EXPR} from "angular2/src/facade/lang";\n' +

--- a/test/literal_test.ts
+++ b/test/literal_test.ts
@@ -40,8 +40,10 @@ describe('literals', () => {
     expectTranslate('1.23e-4').to.equal(' 1.23e-4 ;');
   });
 
-  it('translates regexp literals',
-     () => { expectTranslate('/wo\\/t?/').to.equal(' /wo\\/t?/ ;'); });
+  it('translates regexp literals', () => {
+    expectTranslate('/wo\\/t?/').to.equal(' new RegExp ( r\'wo\\/t?\' ) ;');
+    expectTranslate('/\'/').to.equal(' new RegExp ( r\'\' + "\'" + r\'\' ) ;');
+  });
 
   it('translates array literals', () => {
     expectTranslate('[1,2]').to.equal(' [ 1 , 2 ] ;');


### PR DESCRIPTION
Translate to "new RegExp" calls with raw strings.
Handle .text and .exec in the façade.

@jelbourn