### PR TITLE
fix: add multiple arguments to Array.concat

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -170,9 +170,16 @@ export class FacadeConverter extends base.TranspilerBase {
     'Array.concat': (c: ts.CallExpression, context: ts.Expression) => {
       this.emit('new List . from (');
       this.visit(context);
-      this.emit(') .. addAll (');
-      this.visit(c.arguments[0]);
       this.emit(')');
+      c.arguments.forEach(arg => {
+        var symbol = this.tc.getTypeAtLocation(arg).getSymbol();
+        if (!symbol || this.tc.getFullyQualifiedName(symbol) !== 'Array') {
+          this.reportError(arg, 'Array.concat only supports Array args');
+        }
+        this.emit('.. addAll (');
+        this.visit(arg);
+        this.emit(')');
+      });
     },
     'ArrayConstructor.isArray': (c: ts.CallExpression, context: ts.Expression) => {
       this.emit('( (');

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -66,7 +66,9 @@ describe('type based translation', () => {
                     '( 0, [ 1 , 2 , 3 ]) ) . length ; x . removeAt ( 0 ) ;');
       expectWithTypes('var x: Array<number> = []; x.unshift(1);')
           .to.equal(' List < num > x = [ ] ; ( x .. insert ( 0, 1 ) ) . length ;');
-
+      expectWithTypes('var x: Array<number> = []; x.concat([1], x);')
+          .to.equal(
+              ' List < num > x = [ ] ; new List . from ( x ) .. addAll ( [ 1 ] ) .. addAll ( x ) ;');
     });
 
     it('translates map operations to dartisms', () => {
@@ -132,12 +134,21 @@ describe('type based translation', () => {
   });
 
   describe('error detection', () => {
+    describe('Array', () => {
+      it('.concat() should report an error if any arg is not an Array', () => {
+        chai.expect(() => translateSource('var x: Array<number> = []; x.concat(1);', COMPILE_OPTS))
+            .to.throw('Array.concat only supports Array args');
+      });
+    });
+
     it('for untyped symbols matching special cased fns', () => {
       expectErroneousWithType('forwardRef(1)').to.throw(/Untyped property access to "forwardRef"/);
     });
+
     it('for untyped symbols matching special cased methods', () => {
       expectErroneousWithType('x.push(1)').to.throw(/Untyped property access to "push"/);
     });
+
     it('allows unrelated methods', () => {
       expectWithTypes('import {X} from "other/file";\n' +
                       'new X().map(1)')


### PR DESCRIPTION
@mprobst let's discuss next week on how to add a type test

