### PR TITLE
fix(RegExp): properly escape single quotes

### DIFF
--- a/lib/literal.ts
+++ b/lib/literal.ts
@@ -99,7 +99,7 @@ class LiteralTranspiler extends base.TranspilerBase {
         var slashIdx = regExp.lastIndexOf('/');
         var flags = regExp.substring(slashIdx + 1);
         regExp = regExp.substring(1, slashIdx);  // cut off /.../ chars.
-        regExp = regExp.replace('\'', '\' + "\'" + r\'');  // handle nested quotes by concatenation.
+        regExp = regExp.replace(/'/g, '\' + "\'" + r\'');  // handle nested quotes by concatenation.
         this.emitNoSpace(regExp);
         this.emitNoSpace('\'');
         if (flags.indexOf('g') === -1) {

--- a/test/literal_test.ts
+++ b/test/literal_test.ts
@@ -43,6 +43,7 @@ describe('literals', () => {
   it('translates regexp literals', () => {
     expectTranslate('/wo\\/t?/g').to.equal(' new RegExp ( r\'wo\\/t?\' ) ;');
     expectTranslate('/\'/g').to.equal(' new RegExp ( r\'\' + "\'" + r\'\' ) ;');
+    expectTranslate('/\'o\'/g').to.equal(' new RegExp ( r\'\' + "\'" + r\'o\' + "\'" + r\'\' ) ;');
     expectTranslate('/abc/gmi')
         .to.equal(' new RegExp ( r\'abc\' , multiline: true , caseSensitive: false ) ;');
     expectErroneousCode('/abc/').to.throw(/Regular Expressions must use the \/\/g flag/);


### PR DESCRIPTION
`replace(string)` replaces the first occurrence only