### PR TITLE
fix(HttpRequest): Fix wrong XmlHttpRequestMapping

### DIFF
--- a/lib/module.ts
+++ b/lib/module.ts
@@ -18,7 +18,7 @@ export default class ModuleTranspiler extends base.TranspilerBase {
           this.emit(this.getLibraryName());
           this.emit(';');
         }
-        this.fc.buildImports(<ts.SourceFile>node);
+        this.fc.extraImports(<ts.SourceFile>node);
         ts.forEachChild(node, this.visit.bind(this));
         break;
       case ts.SyntaxKind.EndOfFileToken:

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -18,6 +18,7 @@ export default class ModuleTranspiler extends base.TranspilerBase {
           this.emit(this.getLibraryName());
           this.emit(';');
         }
+        this.fc.buildImports(<ts.SourceFile>node);
         ts.forEachChild(node, this.visit.bind(this));
         break;
       case ts.SyntaxKind.EndOfFileToken:

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -67,6 +67,8 @@ describe('type based translation', () => {
       expectWithTypes('import {Promise} from "angular2/src/facade/async"; x instanceof Promise;')
           .to.equal(' import "package:angular2/src/facade/async.dart" show Future ; x is Future ;');
       expectWithTypes('var n: Node;').to.equal(' dynamic n ;');
+      expectWithTypes('var _xhr: XMLHttpRequest;')
+          .to.equal(' import "dart:html"; HttpRequest _xhr ;');
     });
 
     it('allows undeclared types',


### PR DESCRIPTION
* fixes https://github.com/angular/ts2dart/issues/245

I've tried to solve it in the best way I could. I've been reviewing the code and it doesn't seem there's a way to globally generate imports at the beginning of the file so I added a `buildImports` method to facade_converter that seemed like the more suitable place to handle type>import mapping.

Thanks!