### PR TITLE
fix(CallTranspiler): handle NewExpressions without parameter lists

### DIFF
--- a/lib/call.ts
+++ b/lib/call.ts
@@ -54,7 +54,7 @@ class CallTranspiler extends base.TranspilerBase {
       this.maybeVisitTypeArguments(c);
     }
     this.emit('(');
-    if (!this.handleNamedParamsCall(c)) {
+    if (c.arguments && !this.handleNamedParamsCall(c)) {
       this.visitList(c.arguments);
     }
     this.emit(')');

--- a/test/call_test.ts
+++ b/test/call_test.ts
@@ -46,4 +46,6 @@ describe('calls', () => {
     expectTranslate('class X { y() { super.z(1); } }')
         .to.equal(' class X { y ( ) { super . z ( 1 ) ; } }');
   });
+  it('transpiles new calls without arguments',
+     () => { expectTranslate('new Foo;').to.equal(' new Foo ( ) ;'); });
 });


### PR DESCRIPTION
Previously, ts2dart would crash in the event of an expression like `new
<callee>;` rather than `new <callee>();`.

This minor adjustment improves compat with TypeScript, and is less of a
pain.