### PR TITLE
fix(Array.concat): enclose generated expression in parenthesis

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -290,7 +290,7 @@ export class FacadeConverter extends base.TranspilerBase {
       this.emitCall('ListWrapper.splice', [context, ...c.arguments]);
     },
     'Array.concat': (c: ts.CallExpression, context: ts.Expression) => {
-      this.emit('new List . from (');
+      this.emit('( new List . from (');
       this.visit(context);
       this.emit(')');
       c.arguments.forEach(arg => {
@@ -301,6 +301,7 @@ export class FacadeConverter extends base.TranspilerBase {
         this.visit(arg);
         this.emit(')');
       });
+      this.emit(')');
     },
     'ArrayConstructor.isArray': (c: ts.CallExpression, context: ts.Expression) => {
       this.emit('( (');

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -101,9 +101,9 @@ describe('type based translation', () => {
                     '( 0, [ 1 , 2 , 3 ]) ) . length ; x . removeAt ( 0 ) ;');
       expectWithTypes('var x: Array<number> = []; x.unshift(1);')
           .to.equal(' List < num > x = [ ] ; ( x .. insert ( 0, 1 ) ) . length ;');
-      expectWithTypes('var x: Array<number> = []; x.concat([1], x);')
+      expectWithTypes('var x: Array<number> = []; x.concat([1], x).length;')
           .to.equal(
-              ' List < num > x = [ ] ; new List . from ( x ) .. addAll ( [ 1 ] ) .. addAll ( x ) ;');
+              ' List < num > x = [ ] ; ( new List . from ( x ) .. addAll ( [ 1 ] ) .. addAll ( x ) ) . length ;');
       expectWithTypes('var x: Array<number> = []; var y: Array<number> = x.slice(0);')
           .to.equal(' List < num > x = [ ] ; List < num > y = ListWrapper.slice ( x , 0 ) ;');
       expectWithTypes('var x: Array<number> = []; var y: Array<number> = x.splice(0,1);')


### PR DESCRIPTION
fix #273

Required as '.' has higher priority over '..'