### PR TITLE
Remove fs-extra dependency from main.ts

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,7 +1,6 @@
 require('source-map-support').install();
 import SourceMap = require('source-map');
 import fs = require('fs');
-import fsx = require('fs-extra');
 import path = require('path');
 import ts = require('typescript');
 
@@ -107,7 +106,7 @@ export class Transpiler {
         .forEach((f: ts.SourceFile) => {
           var dartCode = this.translate(f);
           var outputFile = this.getOutputPath(f.fileName, destinationRoot);
-          fsx.mkdirsSync(path.dirname(outputFile));
+          this.recursiveMkdirSync(path.dirname(outputFile));
           fs.writeFileSync(outputFile, dartCode);
         });
     this.checkForErrors(program);
@@ -172,6 +171,39 @@ export class Transpiler {
     this.lastCommentIdx = -1;
     this.visit(sourceFile);
     return this.output.getResult();
+  }
+
+  private recursiveMkdirSync(p: string) {
+    // Simplified version of mkdirSync from https://github.com/jprichardson/node-fs-extra
+    // to avoid bringing in whole lot of module dependencies.
+    var o777 = parseInt('0777', 8);
+    var mode = o777 & (~process.umask());
+
+    p = path.resolve(p);
+
+    try {
+      fs.mkdirSync(p, mode);
+    } catch (error) {
+      switch (error.code) {
+        case 'ENOENT':
+          this.recursiveMkdirSync(path.dirname(p));
+          this.recursiveMkdirSync(p);
+          break;
+
+        // In the case of any other error, just see if there's a dir
+        // there already.  If so, then hooray!  If not, then something
+        // is borked.
+        default:
+          var stat: fs.Stats;
+          try {
+            stat = fs.statSync(p);
+          } catch (statError) {
+            throw(error);
+          }
+          if (!stat.isDirectory()) throw error;
+          break;
+      }
+    }
   }
 
   private checkForErrors(program: ts.Program) {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -106,7 +106,7 @@ export class Transpiler {
         .forEach((f: ts.SourceFile) => {
           var dartCode = this.translate(f);
           var outputFile = this.getOutputPath(f.fileName, destinationRoot);
-          this.recursiveMkdirSync(path.dirname(outputFile));
+          Transpiler.recursiveMkdirSync(path.dirname(outputFile));
           fs.writeFileSync(outputFile, dartCode);
         });
     this.checkForErrors(program);
@@ -173,7 +173,7 @@ export class Transpiler {
     return this.output.getResult();
   }
 
-  private recursiveMkdirSync(p: string) {
+  private static recursiveMkdirSync(p: string) {
     // Simplified version of mkdirSync from https://github.com/jprichardson/node-fs-extra
     // to avoid bringing in whole lot of module dependencies.
     var o777 = parseInt('0777', 8);
@@ -186,8 +186,8 @@ export class Transpiler {
     } catch (error) {
       switch (error.code) {
         case 'ENOENT':
-          this.recursiveMkdirSync(path.dirname(p));
-          this.recursiveMkdirSync(p);
+          Transpiler.recursiveMkdirSync(path.dirname(p));
+          Transpiler.recursiveMkdirSync(p);
           break;
 
         // In the case of any other error, just see if there's a dir

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test": "test"
   },
   "dependencies": {
-    "fs-extra": "^0.18.0",
     "minimist": "^1.1.1",
     "source-map": "^0.4.2",
     "source-map-support": "^0.3.1",
@@ -17,6 +16,7 @@
   "devDependencies": {
     "chai": "^2.1.1",
     "clang-format": "^1.0.25",
+    "fs-extra": "^0.18.0",
     "gulp": "^3.8.11",
     "gulp-clang-format": "^1.0.21",
     "gulp-mocha": "^2.0.0",


### PR DESCRIPTION
Remove fs-extra from the main package dependencies to avoid pulling in all the packages fs-extra depends on.

Move fs-extra to devDependencies as it's still needed for gulp tasks.