### PR TITLE
t2sdart changes needed to use ts2dart within Google

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart # NodeJS is available everywhere
 sudo: false
 node_js:
-  - "stable"
+  - '4.2.1'
 before_script:
   - npm install
 script:

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -81,7 +81,7 @@ export class Transpiler {
    */
   transpile(fileNames: string[], destination?: string): void {
     if (this.options.basePath) {
-      this.options.basePath = this.normalizeSlashes(this.options.basePath);
+      this.options.basePath = this.normalizeSlashes(path.resolve(this.options.basePath));
     }
     fileNames = fileNames.map((f) => this.normalizeSlashes(f));
     var host = this.createCompilerHost();
@@ -213,9 +213,8 @@ export class Transpiler {
    */
   getRelativeFileName(filePath?: string) {
     if (filePath === undefined) filePath = this.currentFile.fileName;
-    // TODO(martinprobst): Use path.isAbsolute on node v0.12.
-    if (this.normalizeSlashes(path.resolve('/x/', filePath)) !== filePath) {
-      return filePath;  // already relative.
+    if (!path.isAbsolute(filePath)) {
+      filePath = path.resolve(filePath);
     }
     var base = this.options.basePath || '';
     if (filePath.indexOf(base) !== 0 && !filePath.match(/\.d\.ts$/)) {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -5,6 +5,7 @@ import path = require('path');
 import ts = require('typescript');
 
 import base = require('./base');
+import mkdirP from './mkdirp';
 import CallTranspiler = require('./call');
 import DeclarationTranspiler = require('./declaration');
 import ExpressionTranspiler = require('./expression');
@@ -106,7 +107,7 @@ export class Transpiler {
         .forEach((f: ts.SourceFile) => {
           var dartCode = this.translate(f);
           var outputFile = this.getOutputPath(f.fileName, destinationRoot);
-          Transpiler.recursiveMkdirSync(path.dirname(outputFile));
+          mkdirP(path.dirname(outputFile));
           fs.writeFileSync(outputFile, dartCode);
         });
     this.checkForErrors(program);
@@ -172,39 +173,6 @@ export class Transpiler {
     this.lastCommentIdx = -1;
     this.visit(sourceFile);
     return this.output.getResult();
-  }
-
-  private static recursiveMkdirSync(p: string) {
-    // Simplified version of mkdirSync from https://github.com/jprichardson/node-fs-extra
-    // to avoid bringing in whole lot of module dependencies.
-    var o777 = parseInt('0777', 8);
-    var mode = o777 & (~process.umask());
-
-    p = path.resolve(p);
-
-    try {
-      fs.mkdirSync(p, mode);
-    } catch (error) {
-      switch (error.code) {
-        case 'ENOENT':
-          Transpiler.recursiveMkdirSync(path.dirname(p));
-          Transpiler.recursiveMkdirSync(p);
-          break;
-
-        // In the case of any other error, just see if there's a dir
-        // there already.  If so, then hooray!  If not, then something
-        // is borked.
-        default:
-          var stat: fs.Stats;
-          try {
-            stat = fs.statSync(p);
-          } catch (statError) {
-            throw(error);
-          }
-          if (!stat.isDirectory()) throw error;
-          break;
-      }
-    }
   }
 
   private checkForErrors(program: ts.Program) {

--- a/lib/mkdirp.ts
+++ b/lib/mkdirp.ts
@@ -4,11 +4,14 @@ import * as path from 'path';
 
 export default function mkdirP(p: string) {
   let absPath = process.cwd();
+  if (path.isAbsolute(p)) {
+    p = path.relative(absPath, p);
+  }
 
   p.split(path.sep).forEach(dirName => {
     absPath = path.join(absPath, dirName);
     if (!fs.existsSync(absPath)) {
-      fs.mkdir(absPath);
+      fs.mkdirSync(absPath);
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "Martin Probst <martinprobst@google.com> (https://angularjs.org/)"
   ],
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">= 4.2.1 < 5"
+  },
   "bugs": {
     "url": "https://github.com/angular/ts2dart/issues"
   },

--- a/test/main_test.ts
+++ b/test/main_test.ts
@@ -44,10 +44,11 @@ describe('main transpiler functionality', () => {
 
   describe('output paths', () => {
     it('writes within the path', () => {
-      var transpiler = new main.Transpiler({basePath: '/a'});
-      chai.expect(transpiler.getOutputPath('/a/b/c.js', '/x')).to.equal('/x/b/c.dart');
-      chai.expect(transpiler.getOutputPath('b/c.js', '/x')).to.equal('/x/b/c.dart');
-      chai.expect(transpiler.getOutputPath('b/c.js', 'x')).to.equal('x/b/c.dart');
+      var cwd = process.cwd();
+      var transpiler = new main.Transpiler({basePath: cwd + '/a'});
+      chai.expect(transpiler.getOutputPath(cwd + '/a/b/c.js', '/x')).to.equal('/x/b/c.dart');
+      chai.expect(transpiler.getOutputPath('a/b/c.js', '/x')).to.equal('/x/b/c.dart');
+      chai.expect(transpiler.getOutputPath('a/b/c.js', 'x')).to.equal('x/b/c.dart');
       chai.expect(() => transpiler.getOutputPath('/outside/b/c.js', '/x'))
           .to.throw(/must be located under base/);
     });

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -58,29 +58,32 @@ describe('exports', () => {
 });
 
 describe('library name', () => {
+  var cwd: string;
   var transpiler: main.Transpiler;
   var modTranspiler: ModuleTranspiler;
   beforeEach(() => {
-    transpiler = new main.Transpiler({failFast: true, generateLibraryName: true, basePath: '/a'});
+    cwd = process.cwd();
+    transpiler =
+        new main.Transpiler({failFast: true, generateLibraryName: true, basePath: cwd + '/a'});
     modTranspiler = new ModuleTranspiler(transpiler, new FacadeConverter(transpiler), true);
   });
   it('adds a library name', () => {
     var results = translateSources(
-        {'/a/b/c.ts': 'var x;'}, {failFast: true, generateLibraryName: true, basePath: '/a'});
-    chai.expect(results['/a/b/c.ts']).to.equal(' library b.c ; var x ;');
+        {'a/b/c.ts': 'var x;'}, {failFast: true, generateLibraryName: true, basePath: cwd + '/a'});
+    chai.expect(results['a/b/c.ts']).to.equal(' library b.c ; var x ;');
   });
-  it('leaves relative paths alone',
-     () => { chai.expect(modTranspiler.getLibraryName('a/b')).to.equal('a.b'); });
+  it('handles relative paths',
+     () => { chai.expect(modTranspiler.getLibraryName('a/b')).to.equal('b'); });
   it('handles reserved words', () => {
-    chai.expect(modTranspiler.getLibraryName('/a/for/in/do/x')).to.equal('_for._in._do.x');
+    chai.expect(modTranspiler.getLibraryName(cwd + '/a/for/in/do/x')).to.equal('_for._in._do.x');
   });
   it('handles built-in and limited keywords', () => {
-    chai.expect(modTranspiler.getLibraryName('/a/as/if/sync/x')).to.equal('as._if.sync.x');
+    chai.expect(modTranspiler.getLibraryName(cwd + '/a/as/if/sync/x')).to.equal('as._if.sync.x');
   });
   it('handles file extensions', () => {
-    chai.expect(modTranspiler.getLibraryName('a/x.ts')).to.equal('a.x');
-    chai.expect(modTranspiler.getLibraryName('a/x.js')).to.equal('a.x');
+    chai.expect(modTranspiler.getLibraryName('a/x.ts')).to.equal('x');
+    chai.expect(modTranspiler.getLibraryName('a/x.js')).to.equal('x');
   });
   it('handles non word characters',
-     () => { chai.expect(modTranspiler.getLibraryName('a/%x.ts')).to.equal('a._x'); });
+     () => { chai.expect(modTranspiler.getLibraryName('a/%x.ts')).to.equal('_x'); });
 });


### PR DESCRIPTION
1. Switch to Igor's mkdirP implementation removing inlined fs-extra code.
2. Allow basePath to be applied even to relative file names.
3. Fix mkdirP issues - Accept relative path name and call fs.mkdirSync that completes synchronously.