### PR TITLE
feat: support loading rxjs from node_modules.

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -246,8 +246,7 @@ export class FacadeConverter extends base.TranspilerBase {
     'lib.es6': this.stdlibTypeReplacements,
     'angular2/typings/es6-promise/es6-promise': {'Promise': 'Future'},
     'angular2/typings/es6-shim/es6-shim': {'Promise': 'Future'},
-    'angular2/src/facade/async':
-        {'Observable': 'Stream', 'ObservableController': 'StreamController'},
+    '../../../../../../rxjs/Observable': {'Observable': 'Stream'},
     'angular2/src/facade/lang': {'Date': 'DateTime'},
   };
 

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -31,9 +31,13 @@ function getSources(str: string): {[k: string]: string} {
         export declare function forwardRef<T>(x: T): T;`,
     'angular2/typings/es6-promise/es6-promise.d.ts': `
         export declare class Promise<R> {}`,
+    'rxjs/Observable.d.ts': `
+      declare module 'rxjs/Observable' {
+        class Observable {}
+      }`,
     'angular2/src/facade/async.ts': `
-        export {Promise} from "angular2/typings/es6-promise/es6-promise";
-        export declare class Observable {};`,
+        export {Promise} from 'angular2/typings/es6-promise/es6-promise';
+        export {Observable} from 'rxjs/Observable';`,
     'angular2/src/facade/collection.ts': `
         export declare var Map;`,
     'angular2/src/facade/lang.d.ts': `


### PR DESCRIPTION
Angular no longer declares Observable itself, but rather re-exports from
rxjs/Observable. This change adjusts to the new location, and also
supports loading from node_modules.