### PR TITLE
fix breaking changes in API introduces in TS-1.8

### DIFF
--- a/lib/base.ts
+++ b/lib/base.ts
@@ -62,7 +62,7 @@ export class TranspilerBase {
   }
 
   isConst(decl: ClassLike) {
-    return this.hasAnnotation(decl.decorators, 'CONST') || decl.members.some((m) => {
+    return this.hasAnnotation(decl.decorators, 'CONST') || (<ts.NodeArray<ts.Declaration>>decl.members).some((m) => {
       if (m.kind !== ts.SyntaxKind.Constructor) return false;
       return this.hasAnnotation(m.decorators, 'CONST');
     });

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -360,14 +360,14 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
         this.visitProperty(param, true);
       }
     };
-    decl.members.filter((m) => m.kind == ts.SyntaxKind.Constructor)
+    (<ts.NodeArray<ts.Declaration>>decl.members).filter((m) => m.kind == ts.SyntaxKind.Constructor)
         .forEach(
             (ctor) =>
                 (<ts.ConstructorDeclaration>ctor).parameters.forEach(synthesizePropertyParam));
     this.visitEachIfPresent(decl.members);
 
     // Generate a constructor to host the const modifier, if needed
-    if (this.isConst(decl) && !decl.members.some((m) => m.kind == ts.SyntaxKind.Constructor)) {
+    if (this.isConst(decl) && !(<ts.NodeArray<ts.Declaration>>decl.members).some((m) => m.kind == ts.SyntaxKind.Constructor)) {
       this.emit("const");
       this.fc.visitTypeName(decl.name);
       this.emit("();")


### PR DESCRIPTION
added a few upcases that were previously unnecessary because the same result was obtained via subtype reduction