### PR TITLE
Implement an inlined facade for Promises

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,10 +85,11 @@ gulp.task('test.e2e', ['test.compile'], function(done) {
   if (fs.existsSync(dir)) fsx.removeSync(dir);
   fs.mkdirSync(dir);
   fsx.copySync(__dirname + '/test/e2e', dir);
+  fsx.copySync(__dirname + '/typings', dir + '/typings');
 
   // run node with a shell so we can wildcard all the .ts files
   var cmd = 'node ../lib/main.js --translateBuiltins --basePath=. --destination=. ' +
-      '*.ts angular2/src/facade/lang.d.ts';
+      '*.ts angular2/src/facade/lang.d.ts typings/es6-promise/es6-promise.d.ts';
   // Paths must be relative to our source root, so run with cwd == dir.
   spawn('sh', ['-c', cmd], {stdio: 'inherit', cwd: dir}).on('close', function(code, signal) {
     if (code > 0) {

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -14,6 +14,7 @@ export function ident(n: ts.Node): string {
 }
 
 export class TranspilerBase {
+  private id_: number = 0;
   constructor(private transpiler: Transpiler) {}
 
   visit(n: ts.Node) { this.transpiler.visit(n); }
@@ -33,6 +34,18 @@ export class TranspilerBase {
     for (var i = 0; i < nodes.length; i++) {
       this.visit(nodes[i]);
       if (i < nodes.length - 1) this.emit(separator);
+    }
+  }
+
+  uniqueId(name: string): string {
+    const id = this.id_++;
+    return `_${name}\$\$ts2dart\$${id}`;
+  }
+
+  assert(c: ts.Node, condition: boolean, reason: string): void {
+    if (!condition) {
+      this.reportError(c, reason);
+      throw new Error(reason);
     }
   }
 

--- a/lib/call.ts
+++ b/lib/call.ts
@@ -16,15 +16,18 @@ export default class CallTranspiler extends base.TranspilerBase {
         }
         return false;
       case ts.SyntaxKind.NewExpression:
+        var newExpr = <ts.NewExpression>node;
         if (this.hasAncestor(node, ts.SyntaxKind.Decorator)) {
           // Constructor calls in annotations must be const constructor calls.
           this.emit('const');
         } else if (this.isInsideConstExpr(node)) {
           this.emit('const');
         } else {
-          this.emit('new');
+          // Some implementations can replace the `new` keyword.
+          if (this.fc.shouldEmitNew(newExpr)) {
+            this.emit('new');
+          }
         }
-        var newExpr = <ts.NewExpression>node;
         if (this.fc.maybeHandleCall(newExpr)) break;
         this.visitCall(newExpr);
         break;

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -70,7 +70,7 @@ export default class TypeTranspiler extends base.TranspilerBase {
         break;
       case ts.SyntaxKind.Identifier:
         var ident = <ts.Identifier>node;
-        this.emit(ident.text);
+        this.fc.visitTypeName(ident);
         break;
       case ts.SyntaxKind.NumberKeyword:
         this.emit('num');

--- a/test/e2e/helloworld.ts
+++ b/test/e2e/helloworld.ts
@@ -1,4 +1,5 @@
 /// <reference path="./test.d.ts"/>
+/// <reference path="./typings/es6-promise/es6-promise.d.ts"/>
 import t = require("test/test");
 import {MyClass, MySubclass, SomeArray} from './lib';
 
@@ -26,4 +27,9 @@ function main(): void {
     t.expect(/o/g.exec("fo.o").length, t.equals(2));
   });
   t.test("const expr", function() { t.expect(SomeArray[0], t.equals(1)); });
+
+  t.test("promises", function() {
+    let p: Promise<number> = new Promise<number>((resolve) => { resolve(1); });
+    p.then((n) => { t.expect(n, t.equals(1)); });
+  });
 }

--- a/tsd.json
+++ b/tsd.json
@@ -25,6 +25,9 @@
     },
     "minimist/minimist.d.ts": {
       "commit": "8b7cc13f6dbabd0a49de7ccba75c342160e600ad"
+    },
+    "es6-promise/es6-promise.d.ts": {
+      "commit": "bcd5761826eb567876c197ccc6a87c4d05731054"
     }
   }
 }


### PR DESCRIPTION
After this we don't need a Promise facade, unless for `all`, `catch` and `race`. I need a handler for `then(a, b)` => `then(a).catch(b)`.