### PR TITLE
feat: ignore return types on function expressions.

### DIFF
--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -255,8 +255,10 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
     this.fc.pushTypeParameterNames(fn);
     try {
       if (fn.type) {
-        if (fn.kind === ts.SyntaxKind.ArrowFunction) {
-          // Type is silently dropped for arrow functions, not supported in Dart.
+        if (fn.kind === ts.SyntaxKind.ArrowFunction ||
+            fn.kind === ts.SyntaxKind.FunctionExpression) {
+          // The return type is silently dropped for function expressions (including arrow
+          // functions), it is not supported in Dart.
           this.emit('/*');
           this.visit(fn.type);
           this.emit('*/');

--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -41,6 +41,12 @@ describe('functions', () => {
     expectTranslate('var a = (p = null) => isBlank(p)')
         .to.equal('var a = ([p = null]) => isBlank(p);');
   });
+  it('translates types on function expressions', () => {
+    expectTranslate('let a = function(p: string): string { return p; };')
+        .to.equal(`var a = /* String */ (String p) {
+  return p;
+};`);
+  });
   it('supports function parameters', () => {
     expectTranslate('function f(fn: (a: A, b: B) => C) {}').to.equal('f(C fn(A a, B b)) {}');
   });


### PR DESCRIPTION
Same as for arrow functions, Dart does not have a syntax for return types.

Fixes #355.