### PR TITLE
feat: transpile console.log to print (#352)

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -506,6 +506,17 @@ export class FacadeConverter extends base.TranspilerBase {
       this.emit('is List');
       this.emit(')');
     },
+    'Console.log': (c: ts.CallExpression, context: ts.Expression) => {
+      this.emit('print(');
+      if (c.arguments.length === 1) {
+        this.visit(c.arguments[0]);
+      } else {
+        this.emit('[');
+        this.visitList(c.arguments);
+        this.emit('].join(" ")');
+      }
+      this.emit(')');
+    },
     'RegExp.test': (c: ts.CallExpression, context: ts.Expression) => {
       this.visit(context);
       this.emitMethodCall('hasMatch', c.arguments);

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -166,6 +166,11 @@ num y = x.fold(0, (a, b) => a + b);`);
 num y = x.fold(null, (a, b) => a + b);`);
     });
 
+    it('translates console.log', () => {
+      expectWithTypes(`console.log(1);`).to.equal('print(1);');
+      expectWithTypes(`console.log(1, 2);`).to.equal('print([1, 2].join(" "));');
+    });
+
     it('translates string methoids',
        () => { expectErroneousWithType(`var x = 'asd'.substr(0, 1);`).to.throw(/use substring/); });
 
@@ -293,9 +298,9 @@ Future<dynamic> x = (() {
 })();
 void fn() {
   x.then((v) {
-    console.log(v);
+    print(v);
   }).catchError((err) {
-    console.log(err);
+    print(err);
   });
 }`);
       expectWithTypes(
@@ -306,9 +311,9 @@ void fn() {
 dynamic /* () => Promise<number> */ fn;
 main() {
   fn().then((v) {
-    console.log(v);
+    print(v);
   }).catchError((err) {
-    console.log(err);
+    print(err);
   });
 }`);
       expectWithTypes(
@@ -319,9 +324,9 @@ main() {
 dynamic /* () => Promise<number> */ fn;
 main() {
   fn().then((v) {
-    console.log(v);
+    print(v);
   }).catchError((err) {
-    console.log(err);
+    print(err);
   });
 }`);
     });


### PR DESCRIPTION
Note: as suggested in the issue, we could transpile to
window.console.log if it had a varargs signature. However, that would
introduce a dependency to dart:html, which seems overkill.