### PR TITLE
Fix RegExp.exec (#194)

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -517,14 +517,38 @@ export class FacadeConverter extends base.TranspilerBase {
       }
       this.emit(')');
     },
+    'RegExp.exec': (c: ts.CallExpression, context: ts.Expression) => {
+      if (context.kind !== ts.SyntaxKind.RegularExpressionLiteral) {
+        // Fail if the exec call isn't made directly on a regexp literal.
+        // Multiple exec calls on the same global regexp have side effects
+        // (each return the next match), which we can't reproduce with a simple
+        // Dart RegExp (users should switch to some facade / wrapper instead).
+        this.reportError(
+            c, 'exec is only supported on regexp literals, ' +
+                'to avoid side-effect of multiple calls on global regexps.');
+      }
+      if (c.parent.kind === ts.SyntaxKind.ElementAccessExpression) {
+        // The result of the exec call is used for immediate indexed access:
+        // this use-case can be accommodated by RegExp.firstMatch, which returns
+        // a Match instance with operator[] which returns groups (special index
+        // 0 returns the full text of the match).
+        this.visit(context);
+        this.emitMethodCall('firstMatch', c.arguments);
+      } else {
+        // In the general case, we want to return a List. To transform a Match
+        // into a List of its groups, we alias it in a local closure that we
+        // call with the Match value. We are then able to use the group method
+        // to generate a List large enough to hold groupCount groups + the
+        // full text of the match at special group index 0.
+        this.emit('((match) => new List.generate(1 + match.groupCount, match.group))(');
+        this.visit(context);
+        this.emitMethodCall('firstMatch', c.arguments);
+        this.emit(')');
+      }
+    },
     'RegExp.test': (c: ts.CallExpression, context: ts.Expression) => {
       this.visit(context);
       this.emitMethodCall('hasMatch', c.arguments);
-    },
-    'RegExp.exec': (c: ts.CallExpression, context: ts.Expression) => {
-      this.visit(context);
-      this.emitMethodCall('allMatches', c.arguments);
-      this.emitMethodCall('toList');
     },
     'String.substr': (c: ts.CallExpression, context: ts.Expression) => {
       this.reportError(

--- a/test/e2e/helloworld.ts
+++ b/test/e2e/helloworld.ts
@@ -29,7 +29,8 @@ function main(): void {
   });
   t.test('regexp', function() {
     t.expect(/o\./g.test('fo.o'), t.equals(true));
-    t.expect(/o/g.exec('fo.o').length, t.equals(2));
+    t.expect(/o/g.exec('fo.o').length, t.equals(1));
+    t.expect(/a(b)/g.exec('ab').length, t.equals(2));
   });
   t.test('const expr', function() { t.expect(SOME_ARRAY[0], t.equals(1)); });
   t.test('generic types fn', function() { t.expect(callOne((a) => a, 1), t.equals(1)); });

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -237,6 +237,17 @@ var y = x.length;`);
   var x = new RegExp(r'a');
   x.hasMatch("a");
 }`);
+    expectWithTypes('function f() { var result = /a(.)/g.exec("ab")[1]; }').to.equal(`f() {
+  var result = new RegExp(r'a(.)').firstMatch("ab")[1];
+}`);
+    expectWithTypes('function f() { let groups = /a(.)/g.exec("ab"); }').to.equal(`f() {
+  var groups = ((match) => new List.generate(
+      1 + match.groupCount, match.group))(new RegExp(r'a(.)').firstMatch("ab"));
+}`);
+    expectErroneousWithType('function f() { var x = /a(.)/g; x.exec("ab")[1]; }')
+        .to.throw(
+            'exec is only supported on regexp literals, ' +
+            'to avoid side-effect of multiple calls on global regexps.');
   });
 
   describe('promises', () => {


### PR DESCRIPTION
- Limit transpilation to direct call on a regexp literal (otherwise, side-effects of multiple calls on a global regexp can't be easily replicated with Dart's RegExp; a quick visitation of the tree could tell us if a regexp is non-global or if `exec` is only called once on it, but that would be overkill so we're just backing out of `x.exec(...)` if `x` is not a `/literal/`)
- Optimize case where `exec` result is only index-accessed